### PR TITLE
Distribute levels

### DIFF
--- a/.ipynb_checkpoints/Untitled-checkpoint.ipynb
+++ b/.ipynb_checkpoints/Untitled-checkpoint.ipynb
@@ -1,0 +1,6 @@
+{
+ "cells": [],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ verify_ssl = true
 
 [packages]
 numpy = "*"
+seaborn = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bc7e66f6a26742e21d302e533ffeb1e4665a7a5e43d6d51b4f3be34fab2cfc5e"
+            "sha256": "0436722e70837a2d903eb5948e3ae3a280985d23afa3b1d125ac2937bf827a1d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,53 @@
         ]
     },
     "default": {
+        "cycler": {
+            "hashes": [
+                "sha256:1d8a5ae1ff6c5cf9b93e8811e581232ad8920aeec647c37316ceac982b08cb2d",
+                "sha256:cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8"
+            ],
+            "version": "==0.10.0"
+        },
+        "kiwisolver": {
+            "hashes": [
+                "sha256:03662cbd3e6729f341a97dd2690b271e51a67a68322affab12a5b011344b973c",
+                "sha256:18d749f3e56c0480dccd1714230da0f328e6e4accf188dd4e6884bdd06bf02dd",
+                "sha256:247800260cd38160c362d211dcaf4ed0f7816afb5efe56544748b21d6ad6d17f",
+                "sha256:443c2320520eda0a5b930b2725b26f6175ca4453c61f739fef7a5847bd262f74",
+                "sha256:4eadb361baf3069f278b055e3bb53fa189cea2fd02cb2c353b7a99ebb4477ef1",
+                "sha256:556da0a5f60f6486ec4969abbc1dd83cf9b5c2deadc8288508e55c0f5f87d29c",
+                "sha256:603162139684ee56bcd57acc74035fceed7dd8d732f38c0959c8bd157f913fec",
+                "sha256:60a78858580761fe611d22127868f3dc9f98871e6fdf0a15cc4203ed9ba6179b",
+                "sha256:7cc095a4661bdd8a5742aaf7c10ea9fac142d76ff1770a0f84394038126d8fc7",
+                "sha256:c31bc3c8e903d60a1ea31a754c72559398d91b5929fcb329b1c3a3d3f6e72113",
+                "sha256:c955791d80e464da3b471ab41eb65cf5a40c15ce9b001fdc5bbc241170de58ec",
+                "sha256:d069ef4b20b1e6b19f790d00097a5d5d2c50871b66d10075dab78938dc2ee2cf",
+                "sha256:d52b989dc23cdaa92582ceb4af8d5bcc94d74b2c3e64cd6785558ec6a879793e",
+                "sha256:e586b28354d7b6584d8973656a7954b1c69c93f708c0c07b77884f91640b7657",
+                "sha256:efcf3397ae1e3c3a4a0a0636542bcad5adad3b1dd3e8e629d0b6e201347176c8",
+                "sha256:fccefc0d36a38c57b7bd233a9b485e2f1eb71903ca7ad7adacad6c28a56d62d2"
+            ],
+            "version": "==1.2.0"
+        },
+        "matplotlib": {
+            "hashes": [
+                "sha256:2466d4dddeb0f5666fd1e6736cc5287a4f9f7ae6c1a9e0779deff798b28e1d35",
+                "sha256:282b3fc8023c4365bad924d1bb442ddc565c2d1635f210b700722776da466ca3",
+                "sha256:4bb50ee4755271a2017b070984bcb788d483a8ce3132fab68393d1555b62d4ba",
+                "sha256:56d3147714da5c7ac4bc452d041e70e0e0b07c763f604110bd4e2527f320b86d",
+                "sha256:7a9baefad265907c6f0b037c8c35a10cf437f7708c27415a5513cf09ac6d6ddd",
+                "sha256:aae7d107dc37b4bb72dcc45f70394e6df2e5e92ac4079761aacd0e2ad1d3b1f7",
+                "sha256:af14e77829c5b5d5be11858d042d6f2459878f8e296228c7ea13ec1fd308eb68",
+                "sha256:c1cf735970b7cd424502719b44288b21089863aaaab099f55e0283a721aaf781",
+                "sha256:ce378047902b7a05546b6485b14df77b2ff207a0054e60c10b5680132090c8ee",
+                "sha256:d35891a86a4388b6965c2d527b9a9f9e657d9e110b0575ca8a24ba0d4e34b8fc",
+                "sha256:e06304686209331f99640642dee08781a9d55c6e32abb45ed54f021f46ccae47",
+                "sha256:e20ba7fb37d4647ac38f3c6d8672dd8b62451ee16173a0711b37ba0ce42bf37d",
+                "sha256:f4412241e32d0f8d3713b68d3ca6430190a5e8a7c070f1c07d7833d8c5264398",
+                "sha256:ffe2f9cdcea1086fc414e82f42271ecf1976700b8edd16ca9d376189c6d93aee"
+            ],
+            "version": "==3.2.1"
+        },
         "numpy": {
             "hashes": [
                 "sha256:1598a6de323508cfeed6b7cd6c4efb43324f4692e20d1f76e1feec7f59013448",
@@ -42,6 +89,89 @@
             ],
             "index": "pypi",
             "version": "==1.18.2"
+        },
+        "pandas": {
+            "hashes": [
+                "sha256:07c1b58936b80eafdfe694ce964ac21567b80a48d972879a359b3ebb2ea76835",
+                "sha256:0ebe327fb088df4d06145227a4aa0998e4f80a9e6aed4b61c1f303bdfdf7c722",
+                "sha256:11c7cb654cd3a0e9c54d81761b5920cdc86b373510d829461d8f2ed6d5905266",
+                "sha256:12f492dd840e9db1688126216706aa2d1fcd3f4df68a195f9479272d50054645",
+                "sha256:167a1315367cea6ec6a5e11e791d9604f8e03f95b57ad227409de35cf850c9c5",
+                "sha256:1a7c56f1df8d5ad8571fa251b864231f26b47b59cbe41aa5c0983d17dbb7a8e4",
+                "sha256:1fa4bae1a6784aa550a1c9e168422798104a85bf9c77a1063ea77ee6f8452e3a",
+                "sha256:32f42e322fb903d0e189a4c10b75ba70d90958cc4f66a1781ed027f1a1d14586",
+                "sha256:387dc7b3c0424327fe3218f81e05fc27832772a5dffbed385013161be58df90b",
+                "sha256:6597df07ea361231e60c00692d8a8099b519ed741c04e65821e632bc9ccb924c",
+                "sha256:743bba36e99d4440403beb45a6f4f3a667c090c00394c176092b0b910666189b",
+                "sha256:858a0d890d957ae62338624e4aeaf1de436dba2c2c0772570a686eaca8b4fc85",
+                "sha256:863c3e4b7ae550749a0bb77fa22e601a36df9d2905afef34a6965bed092ba9e5",
+                "sha256:a210c91a02ec5ff05617a298ad6f137b9f6f5771bf31f2d6b6367d7f71486639",
+                "sha256:ca84a44cf727f211752e91eab2d1c6c1ab0f0540d5636a8382a3af428542826e",
+                "sha256:d234bcf669e8b4d6cbcd99e3ce7a8918414520aeb113e2a81aeb02d0a533d7f7"
+            ],
+            "version": "==1.0.3"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+            ],
+            "version": "==2.4.7"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
+                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
+            ],
+            "version": "==2.8.1"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d",
+                "sha256:b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"
+            ],
+            "version": "==2019.3"
+        },
+        "scipy": {
+            "hashes": [
+                "sha256:00af72998a46c25bdb5824d2b729e7dabec0c765f9deb0b504f928591f5ff9d4",
+                "sha256:0902a620a381f101e184a958459b36d3ee50f5effd186db76e131cbefcbb96f7",
+                "sha256:1e3190466d669d658233e8a583b854f6386dd62d655539b77b3fa25bfb2abb70",
+                "sha256:2cce3f9847a1a51019e8c5b47620da93950e58ebc611f13e0d11f4980ca5fecb",
+                "sha256:3092857f36b690a321a662fe5496cb816a7f4eecd875e1d36793d92d3f884073",
+                "sha256:386086e2972ed2db17cebf88610aab7d7f6e2c0ca30042dc9a89cf18dcc363fa",
+                "sha256:71eb180f22c49066f25d6df16f8709f215723317cc951d99e54dc88020ea57be",
+                "sha256:770254a280d741dd3436919d47e35712fb081a6ff8bafc0f319382b954b77802",
+                "sha256:787cc50cab3020a865640aba3485e9fbd161d4d3b0d03a967df1a2881320512d",
+                "sha256:8a07760d5c7f3a92e440ad3aedcc98891e915ce857664282ae3c0220f3301eb6",
+                "sha256:8d3bc3993b8e4be7eade6dcc6fd59a412d96d3a33fa42b0fa45dc9e24495ede9",
+                "sha256:9508a7c628a165c2c835f2497837bf6ac80eb25291055f56c129df3c943cbaf8",
+                "sha256:a144811318853a23d32a07bc7fd5561ff0cac5da643d96ed94a4ffe967d89672",
+                "sha256:a1aae70d52d0b074d8121333bc807a485f9f1e6a69742010b33780df2e60cfe0",
+                "sha256:a2d6df9eb074af7f08866598e4ef068a2b310d98f87dc23bd1b90ec7bdcec802",
+                "sha256:bb517872058a1f087c4528e7429b4a44533a902644987e7b2fe35ecc223bc408",
+                "sha256:c5cac0c0387272ee0e789e94a570ac51deb01c796b37fb2aad1fb13f85e2f97d",
+                "sha256:cc971a82ea1170e677443108703a2ec9ff0f70752258d0e9f5433d00dda01f59",
+                "sha256:dba8306f6da99e37ea08c08fef6e274b5bf8567bb094d1dbe86a20e532aca088",
+                "sha256:dc60bb302f48acf6da8ca4444cfa17d52c63c5415302a9ee77b3b21618090521",
+                "sha256:dee1bbf3a6c8f73b6b218cb28eed8dd13347ea2f87d572ce19b289d6fd3fbc59"
+            ],
+            "version": "==1.4.1"
+        },
+        "seaborn": {
+            "hashes": [
+                "sha256:59fe414e138d7d5ea08b0feb01b86caf4682e36fa748e3987730523a89aecbb9",
+                "sha256:bdf7714ef7d4603e6325d3902e80a46d6149561e1cc237ac08a1c05c3f55a996"
+            ],
+            "index": "pypi",
+            "version": "==0.10.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
+                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+            ],
+            "version": "==1.14.0"
         }
     },
     "develop": {}

--- a/Untitled.ipynb
+++ b/Untitled.ipynb
@@ -1,0 +1,53 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'seaborn'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-1-8103bdca18c3>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32mimport\u001b[0m \u001b[0mseaborn\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0msb\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'seaborn'"
+     ]
+    }
+   ],
+   "source": [
+    "import seaborn as sb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/src/Class.py
+++ b/src/Class.py
@@ -5,11 +5,19 @@ from seaborn import barplot
 
 
 class Class:
-    def __init__(self, student_count, dueDate):
+    def __init__(self, student_count, dueDate, verbose):
         self.dueDate = dueDate  # considered to be due at 12:01 AM on the dueDate. For example, if it is due on day 10, they have days 0-9 to work on the assignment
         self.today = 0
         self.students = []
-        
+
+        # build the distributions of procrastination and cheat levels
+        procrastinate_levels = []
+        for i in range(len(CHEAT_DISTR)):
+            amountAtLevel_i = int(CHEAT_DISTR[i] * NUM_STUDENTS)
+            for j in range(amountAtLevel_i):
+                procrastinate_levels.append(i)
+
+        print(f"len(procrastiante_levels) = {len(procrastinate_levels)}, NUM_STUDENTS = {NUM_STUDENTS}")
 
 
         # add the students
@@ -22,10 +30,11 @@ class Class:
         needsFriends = [True] * NUM_STUDENTS
         counter = 0
         while (True in needsFriends):
-            print(f'\n========\nROUND {counter}\n========\n')
+            if verbose:
+                print(f'\n========\nROUND {counter}\n========\n')
             for i in range(len(self.students)):
                 if self.students[i].needsFriends():
-                    self.students[i].makeFriends(self.students)
+                    self.students[i].makeFriends(self.students, verbose)
                 needsFriends[i] = self.students[i].needsFriends()
             counter += 1
             if counter == MAX_ITERATIONS:
@@ -33,8 +42,9 @@ class Class:
         if counter == MAX_ITERATIONS:
             print("Maxed Out")
         else:
-            for student in self.students:
-                student.printFriendList()
+            if verbose:
+                for student in self.students:
+                    student.printFriendList()
 
     def useDay(self, report=False):
         if report:

--- a/src/Class.py
+++ b/src/Class.py
@@ -7,7 +7,7 @@ class Class:
     def __init__(self, student_count, dueDate):
         # verbosity for each type of initialization, set to false for deployment (didn't parameterize so it wouldn't be ugly)
         verbose_setFriends = False
-        verbose_buildDistributions = True
+        verbose_buildDistributions = False
 
         # attributes on a class
         self.dueDate = dueDate  # considered to be due at 12:01 AM on the dueDate. For example, if it is due on day 10, they have days 0-9 to work on the assignment
@@ -15,10 +15,13 @@ class Class:
         self.students = []
 
         # build and visualize the distributions of procrastination and cheat levels
-        procrastinate = "procrastinate"
-        cheat = "cheat"
-        procrastinationLevels = self.buildDistribution(PROCRASTINATE_DISTR, verbose_buildDistributions, procrastinate)
-        cheatLevels = self.buildDistribution(CHEAT_DISTR, verbose_buildDistributions, cheat)
+        f, axs = plt.subplots(1, 2)
+        procrastinate = "Procrastination"
+        cheat = "Cheat"
+        procrastinationLevels = self.buildDistribution(PROCRASTINATE_DISTR, verbose_buildDistributions, procrastinate, axs[0])
+        cheatLevels = self.buildDistribution(CHEAT_DISTR, verbose_buildDistributions, cheat, axs[1])
+        plt.ion()
+        plt.show()
 
         # add the students
         for i in range(student_count):
@@ -44,7 +47,7 @@ class Class:
                 for student in self.students:
                     student.printFriendList()
 
-    def buildDistribution(self, distribution, verbose, name):
+    def buildDistribution(self, distribution, verbose, name, chart):
         # perform calculations
         counts = []
         values = []
@@ -65,11 +68,10 @@ class Class:
         # visualize
         labels = [str(i) for i in range(len(distribution))]
         y_pos = range(len(distribution))
-        plt.bar(y_pos, counts, align='center', alpha=.5)
-        plt.xticks(y_pos, labels)
-        plt.ylabel(name)
-        plt.title("Distribution of " + name)
-        plt.show()
+        chart.bar(y_pos, counts, align='center', alpha=.5)
+        # chart.xticks(y_pos, labels)
+        # chart.ylabel.set_text(name)
+        chart.title.set_text("Distribution of " + name)
 
         # return
         shuffle(values)

--- a/src/Class.py
+++ b/src/Class.py
@@ -1,17 +1,21 @@
 from Student import Student
 from configuration import *
 from random import randint
+from seaborn import barplot
+
 
 class Class:
     def __init__(self, student_count, dueDate):
         self.dueDate = dueDate  # considered to be due at 12:01 AM on the dueDate. For example, if it is due on day 10, they have days 0-9 to work on the assignment
         self.today = 0
         self.students = []
+        
+
 
         # add the students
         for i in range(student_count):
-            cheat = randint(*CHEAT_RANGE)
-            procrastinate = randint(*PROCRASTINATION_RANGE)
+            cheat = 2
+            procrastinate = 4
             self.students.append(Student(i, cheat, procrastinate, dueDate))
 
         # set the friends

--- a/src/Class.py
+++ b/src/Class.py
@@ -1,24 +1,23 @@
 from Student import Student
 from configuration import *
-from random import randint
+from random import randint, shuffle
 from seaborn import barplot
 
 
 class Class:
-    def __init__(self, student_count, dueDate, verbose):
+    def __init__(self, student_count, dueDate):
+        # verbosity for each type of initialization, set to false for deployment (didn't parameterize so it wouldn't be ugly)
+        verbose_setFriends = False
+        verbose_buildDistributions = True
+
+        # attributes on a class
         self.dueDate = dueDate  # considered to be due at 12:01 AM on the dueDate. For example, if it is due on day 10, they have days 0-9 to work on the assignment
         self.today = 0
         self.students = []
 
         # build the distributions of procrastination and cheat levels
-        procrastinate_levels = []
-        for i in range(len(CHEAT_DISTR)):
-            amountAtLevel_i = int(CHEAT_DISTR[i] * NUM_STUDENTS)
-            for j in range(amountAtLevel_i):
-                procrastinate_levels.append(i)
-
-        print(f"len(procrastiante_levels) = {len(procrastinate_levels)}, NUM_STUDENTS = {NUM_STUDENTS}")
-
+        procrastinationLevels = self.buildDistribution(PROCRASTINATE_DISTR, verbose_buildDistributions, 'procrastination')
+        cheatLevels = self.buildDistribution(CHEAT_DISTR, verbose_buildDistributions, "cheat")
 
         # add the students
         for i in range(student_count):
@@ -30,11 +29,11 @@ class Class:
         needsFriends = [True] * NUM_STUDENTS
         counter = 0
         while (True in needsFriends):
-            if verbose:
+            if verbose_setFriends:
                 print(f'\n========\nROUND {counter}\n========\n')
             for i in range(len(self.students)):
                 if self.students[i].needsFriends():
-                    self.students[i].makeFriends(self.students, verbose)
+                    self.students[i].makeFriends(self.students, verbose_setFriends)
                 needsFriends[i] = self.students[i].needsFriends()
             counter += 1
             if counter == MAX_ITERATIONS:
@@ -42,9 +41,26 @@ class Class:
         if counter == MAX_ITERATIONS:
             print("Maxed Out")
         else:
-            if verbose:
+            if verbose_setFriends:
                 for student in self.students:
                     student.printFriendList()
+
+    def buildDistribution(self, distribution, verbose, name):
+        values = []
+        for level in range(len(distribution)):
+            quantityAtGivenLevel = int(distribution[level] * NUM_STUDENTS)
+            for i in range(quantityAtGivenLevel):
+                values.append(level)
+        if len(values) != NUM_STUDENTS:
+            for i in range(NUM_STUDENTS - len(values)):
+                values.append(randint(0, len(distribution) - 1))
+        if verbose:
+            print(f"For {name}, values are (before shuffling):")
+            for i in values:
+                print(str(i) + ", ", end='')
+            print()
+        shuffle(values)
+        return values
 
     def useDay(self, report=False):
         if report:

--- a/src/Class.py
+++ b/src/Class.py
@@ -1,8 +1,7 @@
 from Student import Student
 from configuration import *
 from random import randint, shuffle
-from seaborn import barplot
-
+import matplotlib.pyplot as plt
 
 class Class:
     def __init__(self, student_count, dueDate):
@@ -15,15 +14,15 @@ class Class:
         self.today = 0
         self.students = []
 
-        # build the distributions of procrastination and cheat levels
-        procrastinationLevels = self.buildDistribution(PROCRASTINATE_DISTR, verbose_buildDistributions, 'procrastination')
-        cheatLevels = self.buildDistribution(CHEAT_DISTR, verbose_buildDistributions, "cheat")
+        # build and visualize the distributions of procrastination and cheat levels
+        procrastinate = "procrastinate"
+        cheat = "cheat"
+        procrastinationLevels = self.buildDistribution(PROCRASTINATE_DISTR, verbose_buildDistributions, procrastinate)
+        cheatLevels = self.buildDistribution(CHEAT_DISTR, verbose_buildDistributions, cheat)
 
         # add the students
         for i in range(student_count):
-            cheat = 2
-            procrastinate = 4
-            self.students.append(Student(i, cheat, procrastinate, dueDate))
+            self.students.append(Student(i, cheatLevels[i], procrastinationLevels[i], dueDate))
 
         # set the friends
         needsFriends = [True] * NUM_STUDENTS
@@ -46,11 +45,14 @@ class Class:
                     student.printFriendList()
 
     def buildDistribution(self, distribution, verbose, name):
+        # perform calculations
+        counts = []
         values = []
         for level in range(len(distribution)):
             quantityAtGivenLevel = int(distribution[level] * NUM_STUDENTS)
             for i in range(quantityAtGivenLevel):
                 values.append(level)
+            counts.append(quantityAtGivenLevel)
         if len(values) != NUM_STUDENTS:
             for i in range(NUM_STUDENTS - len(values)):
                 values.append(randint(0, len(distribution) - 1))
@@ -59,6 +61,17 @@ class Class:
             for i in values:
                 print(str(i) + ", ", end='')
             print()
+
+        # visualize
+        labels = [str(i) for i in range(len(distribution))]
+        y_pos = range(len(distribution))
+        plt.bar(y_pos, counts, align='center', alpha=.5)
+        plt.xticks(y_pos, labels)
+        plt.ylabel(name)
+        plt.title("Distribution of " + name)
+        plt.show()
+
+        # return
         shuffle(values)
         return values
 

--- a/src/Student.py
+++ b/src/Student.py
@@ -123,8 +123,9 @@ class Student:
                 # self.updateProgress(friend.getWorkPerDay())
                 # friend.updateProgress(self.workPerDay)
 
-    def makeFriends(self, students):
-        print(f'ID is {self.id}, preferredNumFriends is {self.preferredNumFriends}')
+    def makeFriends(self, students, verbose):
+        if verbose:
+            print(f'ID is {self.id}, preferredNumFriends is {self.preferredNumFriends}')
         # validation
         if len(self.friends) >= self.preferredNumFriends:
             raise Exception("Shouldn't be calling Student::makeFriends() when the student already has all their friends")
@@ -139,25 +140,29 @@ class Student:
         # get preferred candidates
         likelyCandidates = self.getFriendsOfFriends()
         if len(likelyCandidates) < MIN_CANDIDATES:
-            print(f'(supplementing existing {len(likelyCandidates)} candidates with new candidates with ids ', end='')
+            if verbose:
+                print(f'(supplementing existing {len(likelyCandidates)} candidates with new candidates with ids ', end='')
             for candidate in allCandidates:
                 if candidate not in likelyCandidates:
                     likelyCandidates.append(candidate)
-            print(')')
+            if verbose:
+                print(')')
 
         # select a candidate
-        print(f'Candidate ids are: ', end='')
-        for candidate in likelyCandidates:
-            print(candidate.id, ', ', end='')
-        print()
-        print(f'Friends before are: ', end='')
-        for friend in self.friends:
-            print(friend.getId(), ", ", end='')
+        if verbose:
+            print(f'Candidate ids are: ', end='')
+            for candidate in likelyCandidates:
+                print(candidate.id, ', ', end='')
+            print()
+            print(f'Friends before are: ', end='')
+            for friend in self.friends:
+                print(friend.getId(), ", ", end='')
         newFriend = self.selectCandidate(likelyCandidates)
         self.friends.append(newFriend)
         newFriend.addFriend(students[self.id])
-        print(f'\nAdded friend {likelyCandidates[0].id}')
-        print('*****')
+        if verbose:
+            print(f'\nAdded friend {likelyCandidates[0].id}')
+            print('*****')
 
 
     def selectCandidate(self, candidates):

--- a/src/Student.py
+++ b/src/Student.py
@@ -4,9 +4,6 @@ from configuration import *
 
 class Student:
     def __init__(self, id, cheat_level, procrastinate_level, dueDate):
-        assert PROCRASTINATION_RANGE[0] <= procrastinate_level <= PROCRASTINATION_RANGE[1]
-        assert CHEAT_RANGE[0] <= cheat_level <= CHEAT_RANGE[1]
-
         self.id = id
         self.cheat_level = cheat_level
         self.procrastinate_level = procrastinate_level

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -1,14 +1,16 @@
 from sys import exit
 
+# demographic configuration
+CHEAT_DISTR = [0, .1, .1, .1, .1, .1, .1, .1, .1, .1, .1]
+PROCRASTINATE_DISTR = [0, .1, .1, .1, .1, .1, .1, .1, .1, .1, .1]
+
 # classroom configuration
 NUM_DAYS = 10
 NUM_STUDENTS = 20
-DAY_DELAY = .75  # senconds
+DAY_DELAY = .75  # seconds
 
 # student configuration
-PROCRASTINATION_RANGE = (0, 10)
-CHEAT_RANGE = (0, 10)
-NUM_PERSONALITIES = 16
+NUM_PERSONALITIES = 5
 MORAL_CHEAT_MIN_REQUEST = 3
 MORAL_CHEAT_MIN_SEND = 2
 
@@ -18,25 +20,30 @@ PROCRASTINATE_TOLERANCE = 7
 MIN_CANDIDATES = 4
 MIN_FRIENDS = 1
 MAX_FRIENDS = 3
-MAX_ITERATIONS = 10000000000
+MAX_ITERATIONS = 1000
 
 # validate configurations
 if (MAX_FRIENDS > NUM_STUDENTS - 1):
     exit("Can't have more friends than students")
 if (MIN_FRIENDS < 0):
     exit("Can't have less than 0 friends")
-if (CHEAT_TOLERANCE > CHEAT_RANGE[1]):
-    exit("CHEAT_TOLERANCE is above the maximum value")
+if (CHEAT_TOLERANCE > 10):
+    exit("CHEAT_TOLERANCE is above 10")
 if (CHEAT_TOLERANCE < 0):
     exit("CHEAT_TOLERANCE is less than 0")
 if (MIN_CANDIDATES > (NUM_STUDENTS - 1)):
     exit("MIN_CANDIDATES is greater than the number of students")
 if (MIN_CANDIDATES < 0):
     exit("MIN_CANDIDATES is less than zero")
-if (PROCRASTINATE_TOLERANCE > PROCRASTINATION_RANGE[1]):
-    exit("PROCRASTINATE_TOLERANCE is greater than max procrastination")
+if (PROCRASTINATE_TOLERANCE > 10):
+    exit("PROCRASTINATE_TOLERANCE is greater than 10")
 if (PROCRASTINATE_TOLERANCE < 0):
     exit("PROCRASINATE_TOLERANCE is less than 0")
-
-
-
+if len(CHEAT_DISTR) != 11:
+    exit("The cheating distribution must have 11 elements, one for each index 0 - 10")
+if len(PROCRASTINATE_DISTR) != 11:
+    exit("The procrastination index must have 11 elements, one for each index 0 - 10")
+if round(sum(CHEAT_DISTR)) != 1:
+    exit(f"The sum of CHEAT_DISTR must equal 1, equals {sum(CHEAT_DISTR)}")
+if round(sum(PROCRASTINATE_DISTR)) != 1:
+    exit(f"The sum of PROCRASTINATE_DISTR must equal 1, equals {sum(PROCRASTINATE_DISTR)}")

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -1,8 +1,16 @@
 from sys import exit
 
+def getSumOfList(p_list):
+    sum = 0
+    for i in p_list:
+        sum += i
+    if abs(1 - sum) < .00001:
+        sum = 1
+    return sum
+
 # demographic configuration
 CHEAT_DISTR = [.1, .1, .1, .1, .1, .1, .1, .1, .1, .1]
-PROCRASTINATE_DISTR = [.1, .1, .1, .1, .1, .1, .1, .1, .1, .1]
+PROCRASTINATE_DISTR = [.9, 0, 0, 0, 0, 0, 0, 0, .1]
 
 # classroom configuration
 NUM_DAYS = 10
@@ -15,31 +23,35 @@ MORAL_CHEAT_MIN_REQUEST = 3
 MORAL_CHEAT_MIN_SEND = 2
 
 # friend generation configuration
-CHEAT_TOLERANCE = 3
-PROCRASTINATE_TOLERANCE = 7
+CHEAT_TOLERANCE = 2
+PROCRASTINATE_TOLERANCE = 1
 MIN_CANDIDATES = 4
 MIN_FRIENDS = 1
 MAX_FRIENDS = 3
 MAX_ITERATIONS = 1000
 
 # validate configurations
+MAX_PROCRASTIATION = len(PROCRASTINATE_DISTR) - 1
+MAX_CHEAT = len(CHEAT_DISTR) - 1
+
 if (MAX_FRIENDS > NUM_STUDENTS - 1):
     exit("Can't have more friends than students")
 if (MIN_FRIENDS < 0):
     exit("Can't have less than 0 friends")
-if (CHEAT_TOLERANCE > (len(CHEAT_DISTR) - 1)):
-    exit(f"CHEAT_TOLERANCE is greater than the max permissible level of {len(CHEAT_DISTR) - 1}.")
+if (CHEAT_TOLERANCE > MAX_CHEAT):
+    exit(f"CHEAT_TOLERANCE is greater than the max permissible level of {MAX_CHEAT}")
 if (CHEAT_TOLERANCE < 0):
     exit("CHEAT_TOLERANCE is less than 0")
 if (MIN_CANDIDATES > (NUM_STUDENTS - 1)):
     exit("MIN_CANDIDATES is greater than the number of students")
 if (MIN_CANDIDATES < 0):
     exit("MIN_CANDIDATES is less than zero")
-if (PROCRASTINATE_TOLERANCE > (len(PROCRASTINATE_DISTR) - 1)):
-    exit(f"PROCRASTINATE_TOLERANCE is greater than the max permissible level of {len(PROCRASTINATE_DISTR - 1)}.")
+if (PROCRASTINATE_TOLERANCE > MAX_PROCRASTIATION):
+    exit(f"PROCRASTINATE_TOLERANCE is greater than the max permissible level of {MAX_PROCRASTIATION}.")
 if (PROCRASTINATE_TOLERANCE < 0):
     exit("PROCRASINATE_TOLERANCE is less than 0")
-if round(sum(CHEAT_DISTR)) != 1:
-    exit(f"The sum of CHEAT_DISTR must equal 1, equals {sum(CHEAT_DISTR)}")
-if round(sum(PROCRASTINATE_DISTR)) != 1:
-    exit(f"The sum of PROCRASTINATE_DISTR must equal 1, equals {sum(PROCRASTINATE_DISTR)}")
+if getSumOfList(CHEAT_DISTR) != 1:
+    exit(f"The sum of CHEAT_DISTR must equal 1, equals {getSumOfList(CHEAT_DISTR)}")
+if getSumOfList(PROCRASTINATE_DISTR) != 1:
+    exit(f"The sum of PROCRASTINATE_DISTR must equal 1, equals {getSumOfList(PROCRASTINATE_DISTR)}")
+

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -9,8 +9,8 @@ def getSumOfList(p_list):
     return sum
 
 # demographic configuration
-CHEAT_DISTR = [.1, .1, .1, .1, .1, .1, .1, .1, .1, .1]
-PROCRASTINATE_DISTR = [.9, 0, 0, 0, 0, 0, 0, 0, .1]
+CHEAT_DISTR = [.7, .1, 0, .1, .1]
+PROCRASTINATE_DISTR = [0, 0, .4, .5, .1]
 
 # classroom configuration
 NUM_DAYS = 10

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -1,6 +1,7 @@
 from sys import exit
 
 def getSumOfList(p_list):
+    # the sum(list) native function didn't do what I wanted it to, so I made this function, then it failed me too
     sum = 0
     for i in p_list:
         sum += i
@@ -9,12 +10,12 @@ def getSumOfList(p_list):
     return sum
 
 # demographic configuration
-CHEAT_DISTR = [.7, .1, 0, .1, .1]
-PROCRASTINATE_DISTR = [0, 0, .4, .5, .1]
+CHEAT_DISTR = [0, .7, .1, 0, .1, .1]
+PROCRASTINATE_DISTR = [0, 0, .4, .2, .1, .2, .1]
 
 # classroom configuration
 NUM_DAYS = 10
-NUM_STUDENTS = 20
+NUM_STUDENTS = 25
 DAY_DELAY = .75  # seconds
 
 # student configuration

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -1,8 +1,8 @@
 from sys import exit
 
 # demographic configuration
-CHEAT_DISTR = [0, .1, .1, .1, .1, .1, .1, .1, .1, .1, .1]
-PROCRASTINATE_DISTR = [0, .1, .1, .1, .1, .1, .1, .1, .1, .1, .1]
+CHEAT_DISTR = [.1, .1, .1, .1, .1, .1, .1, .1, .1, .1]
+PROCRASTINATE_DISTR = [.1, .1, .1, .1, .1, .1, .1, .1, .1, .1]
 
 # classroom configuration
 NUM_DAYS = 10
@@ -27,22 +27,18 @@ if (MAX_FRIENDS > NUM_STUDENTS - 1):
     exit("Can't have more friends than students")
 if (MIN_FRIENDS < 0):
     exit("Can't have less than 0 friends")
-if (CHEAT_TOLERANCE > 10):
-    exit("CHEAT_TOLERANCE is above 10")
+if (CHEAT_TOLERANCE > (len(CHEAT_DISTR) - 1)):
+    exit(f"CHEAT_TOLERANCE is greater than the max permissible level of {len(CHEAT_DISTR) - 1}.")
 if (CHEAT_TOLERANCE < 0):
     exit("CHEAT_TOLERANCE is less than 0")
 if (MIN_CANDIDATES > (NUM_STUDENTS - 1)):
     exit("MIN_CANDIDATES is greater than the number of students")
 if (MIN_CANDIDATES < 0):
     exit("MIN_CANDIDATES is less than zero")
-if (PROCRASTINATE_TOLERANCE > 10):
-    exit("PROCRASTINATE_TOLERANCE is greater than 10")
+if (PROCRASTINATE_TOLERANCE > (len(PROCRASTINATE_DISTR) - 1)):
+    exit(f"PROCRASTINATE_TOLERANCE is greater than the max permissible level of {len(PROCRASTINATE_DISTR - 1)}.")
 if (PROCRASTINATE_TOLERANCE < 0):
     exit("PROCRASINATE_TOLERANCE is less than 0")
-if len(CHEAT_DISTR) != 11:
-    exit("The cheating distribution must have 11 elements, one for each index 0 - 10")
-if len(PROCRASTINATE_DISTR) != 11:
-    exit("The procrastination index must have 11 elements, one for each index 0 - 10")
 if round(sum(CHEAT_DISTR)) != 1:
     exit(f"The sum of CHEAT_DISTR must equal 1, equals {sum(CHEAT_DISTR)}")
 if round(sum(PROCRASTINATE_DISTR)) != 1:

--- a/src/main.py
+++ b/src/main.py
@@ -7,11 +7,11 @@ import time
 
 myClass = Class(NUM_STUDENTS, NUM_DAYS)
 
-# run the simulation
-v = Visual(myClass.students)
-v.showClass()
-for i in range(NUM_DAYS):
-    myClass.useDay(report=True)
-    time.sleep(DAY_DELAY)
-    v.updateClass(myClass.students, i)
-v.dontClose()
+# # run the simulation
+# v = Visual(myClass.students)
+# v.showClass()
+# for i in range(NUM_DAYS):
+#     myClass.useDay(report=True)
+#     time.sleep(DAY_DELAY)
+#     v.updateClass(myClass.students, i)
+# v.dontClose()

--- a/src/main.py
+++ b/src/main.py
@@ -4,8 +4,7 @@ from configuration import *
 from visual import Visual
 import time
 
-verbose = False
-myClass = Class(NUM_STUDENTS, NUM_DAYS, verbose)
+myClass = Class(NUM_STUDENTS, NUM_DAYS)
 
 # # run the simulation
 # v = Visual(myClass.students)

--- a/src/main.py
+++ b/src/main.py
@@ -6,13 +6,11 @@ import time
 
 myClass = Class(NUM_STUDENTS, NUM_DAYS)
 
-while True:
-    pass
 # run the simulation
-# v = Visual(myClass.students)
-# v.showClass()
-# for i in range(NUM_DAYS):
-#     myClass.useDay(report=True)
-#     time.sleep(DAY_DELAY)
-#     v.updateClass(myClass.students, i)
-# v.dontClose()
+v = Visual(myClass.students)
+v.showClass()
+for i in range(NUM_DAYS):
+    myClass.useDay(report=True)
+    time.sleep(DAY_DELAY)
+    v.updateClass(myClass.students, i)
+v.dontClose()

--- a/src/main.py
+++ b/src/main.py
@@ -4,8 +4,8 @@ from configuration import *
 from visual import Visual
 import time
 
-
-myClass = Class(NUM_STUDENTS, NUM_DAYS)
+verbose = False
+myClass = Class(NUM_STUDENTS, NUM_DAYS, verbose)
 
 # # run the simulation
 # v = Visual(myClass.students)

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,9 @@ import time
 
 myClass = Class(NUM_STUDENTS, NUM_DAYS)
 
-# # run the simulation
+while True:
+    pass
+# run the simulation
 # v = Visual(myClass.students)
 # v.showClass()
 # for i in range(NUM_DAYS):


### PR DESCRIPTION
Two new things:

1) You can now configure the distribution of cheating and procrastination levels. To do this, modify the CHEAT_DISTR and PROCRASTINATE_DISTR lists. For each index j in these lists, the floating-point number at index j represents the proportion of students in the class at level j for each characteristic. For example, if CHEAT_DISTR = [.05, .5, .1, .35] means that 5%, 50%, 10%, and 35% of students have cheat levels of 0, 1, 2, and 3, respectively. In doing this, I deleted the CHEAT_RANGE and PROCRASTINATE_RANGE tuples since these ranges are implied by the length of these new lists.

2) A bar chart of the distributions is automatically generated.